### PR TITLE
Fix first_unused_segment

### DIFF
--- a/include/trial/circular/detail/span.ipp
+++ b/include/trial/circular/detail/span.ipp
@@ -463,11 +463,8 @@ constexpr auto span<T, E>::first_unused_segment() const noexcept -> const_segmen
 {
     return (full())
         ? const_segment()
-        : (wraparound()
-           ? const_segment(member.data + back_index() + 1,
-                           member.data + capacity())
-           : const_segment(member.data + back_index() + 1,
-                           member.data + capacity()));
+        : const_segment(member.data + member.next - capacity(),
+                  member.data + std::min(front_index(), capacity()));
 }
 
 template <typename T, std::size_t E>

--- a/include/trial/circular/detail/span.ipp
+++ b/include/trial/circular/detail/span.ipp
@@ -646,7 +646,7 @@ span<T, E>::member_storage<T1, E1>::member_storage(ContiguousIterator begin,
                                                    size_type length) noexcept
     : data(begin == end ? nullptr : &*begin),
       size(length),
-      next(size_type(first - begin) + length)
+      next((capacity() == 0) ? 0 : (capacity() + (size_type(first - begin) + length) % capacity()))
 {
     assert(size_type(end - begin) == capacity());
 }
@@ -756,7 +756,7 @@ constexpr span<T, E>::member_storage<T1, dynamic_extent>::member_storage(Contigu
     : data(begin == end ? nullptr : &*begin),
       cap(size_type(end - begin)),
       size(length),
-      next(size_type(first - begin) + length)
+      next((capacity() == 0) ? 0 : (capacity() + (size_type(first - begin) + length) % capacity()))
 {
 }
 

--- a/test/span_segment_suite.cpp
+++ b/test/span_segment_suite.cpp
@@ -16,8 +16,6 @@
 
 using namespace trial;
 
-#define TEST_CONST_FIRST_UNUSED_SEGMENT 0
-
 //-----------------------------------------------------------------------------
 // P0007
 
@@ -221,11 +219,9 @@ void segment_empty()
         TRIAL_TEST_EQ(segment.data() - array, 0);
         TRIAL_TEST_EQ(segment.size(), 4);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -267,11 +263,9 @@ void segment_partial()
         TRIAL_TEST_EQ(segment.data() - array, 1);
         TRIAL_TEST_EQ(segment.size(), 3);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -307,11 +301,9 @@ void segment_partial()
         TRIAL_TEST_EQ(segment.data() - array, 2);
         TRIAL_TEST_EQ(segment.size(), 2);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -347,11 +339,9 @@ void segment_partial()
         TRIAL_TEST_EQ(segment.data() - array, 3);
         TRIAL_TEST_EQ(segment.size(), 1);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -628,11 +618,9 @@ void segment_overfull_1()
         TRIAL_TEST_EQ(segment.data() - array, 1);
         TRIAL_TEST_EQ(segment.size(), 1);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -669,11 +657,9 @@ void segment_overfull_1()
         TRIAL_TEST_EQ(segment.data() - array, 2);
         TRIAL_TEST_EQ(segment.size(), 1);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -710,11 +696,9 @@ void segment_overfull_1()
         TRIAL_TEST_EQ(segment.data() - array, 3);
         TRIAL_TEST_EQ(segment.size(), 1);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -751,11 +735,9 @@ void segment_overfull_1()
         TRIAL_TEST_EQ(segment.data() - array, 0);
         TRIAL_TEST_EQ(segment.size(), 1);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -792,11 +774,9 @@ void segment_overfull_1()
         TRIAL_TEST_EQ(segment.data() - array, 1);
         TRIAL_TEST_EQ(segment.size(), 1);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -839,11 +819,9 @@ void segment_overfull_2()
         TRIAL_TEST_EQ(segment.data() - array, 1);
         TRIAL_TEST_EQ(segment.size(), 2);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -880,11 +858,9 @@ void segment_overfull_2()
         TRIAL_TEST_EQ(segment.data() - array, 2);
         TRIAL_TEST_EQ(segment.size(), 2);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -921,11 +897,9 @@ void segment_overfull_2()
         TRIAL_TEST_EQ(segment.data() - array, 3);
         TRIAL_TEST_EQ(segment.size(), 1);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -962,11 +936,9 @@ void segment_overfull_2()
         TRIAL_TEST_EQ(segment.data() - array, 0);
         TRIAL_TEST_EQ(segment.size(), 2);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -1003,11 +975,9 @@ void segment_overfull_2()
         TRIAL_TEST_EQ(segment.data() - array, 1);
         TRIAL_TEST_EQ(segment.size(), 2);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -1050,11 +1020,9 @@ void segment_overfull_3()
         TRIAL_TEST_EQ(segment.data() - array, 1);
         TRIAL_TEST_EQ(segment.size(), 3);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -1091,11 +1059,9 @@ void segment_overfull_3()
         TRIAL_TEST_EQ(segment.data() - array, 2);
         TRIAL_TEST_EQ(segment.size(), 2);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -1132,11 +1098,9 @@ void segment_overfull_3()
         TRIAL_TEST_EQ(segment.data() - array, 3);
         TRIAL_TEST_EQ(segment.size(), 1);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -1173,11 +1137,9 @@ void segment_overfull_3()
         TRIAL_TEST_EQ(segment.data() - array, 0);
         TRIAL_TEST_EQ(segment.size(), 3);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -1214,11 +1176,9 @@ void segment_overfull_3()
         TRIAL_TEST_EQ(segment.data() - array, 1);
         TRIAL_TEST_EQ(segment.size(), 3);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -1261,11 +1221,9 @@ void segment_overfull_4()
         TRIAL_TEST_EQ(segment.data() - array, 1);
         TRIAL_TEST_EQ(segment.size(), 3);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -1302,11 +1260,9 @@ void segment_overfull_4()
         TRIAL_TEST_EQ(segment.data() - array, 2);
         TRIAL_TEST_EQ(segment.size(), 2);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -1343,11 +1299,9 @@ void segment_overfull_4()
         TRIAL_TEST_EQ(segment.data() - array, 3);
         TRIAL_TEST_EQ(segment.size(), 1);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -1384,11 +1338,9 @@ void segment_overfull_4()
         TRIAL_TEST_EQ(segment.data() - array, 0);
         TRIAL_TEST_EQ(segment.size(), 4);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();
@@ -1425,11 +1377,9 @@ void segment_overfull_4()
         TRIAL_TEST_EQ(segment.data() - array, 1);
         TRIAL_TEST_EQ(segment.size(), 3);
 
-#if TEST_CONST_FIRST_UNUSED_SEGMENT
         auto const_segment = as_const(span).first_unused_segment();
         TRIAL_TEST_EQ(segment.data(), const_segment.data());
         TRIAL_TEST_EQ(segment.size(), const_segment.size());
-#endif
     }
     {
         auto segment = span.last_unused_segment();

--- a/test/span_suite.cpp
+++ b/test/span_suite.cpp
@@ -552,6 +552,7 @@ void dynamic_first_unused_segment()
 {
     int array[4] = {};
     circular::span<int> span(array);
+    TRIAL_TEST_EQ(span.first_unused_segment().size(), 4);
     span = { 11, 22 };
     auto segment = span.first_unused_segment();
     {
@@ -559,24 +560,51 @@ void dynamic_first_unused_segment()
         TRIAL_TEST_ALL_EQ(segment.data(), segment.data() + segment.size(),
                           expect.begin(), expect.end());
     }
+    span.push_back(33);
+    span.push_back(44);
+    segment = span.first_unused_segment();
+    TRIAL_TEST_EQ(segment.size(), 0);
+
+    span.pop_front();
+    span.pop_front();
+    span.push_back(55);
+    segment = span.first_unused_segment();
+    TRIAL_TEST_EQ(segment.size(), 1);
+    TRIAL_TEST_EQ(*segment.begin(), 22);
 }
 
 void dynamic_first_unused_segment_const()
 {
-    std::array<int, 4> array = { 11, 22 };
-    const circular::span<int> span(array.begin(), array.end(), array.begin(), 2);
-    auto segment = span.first_unused_segment();
+    int array[4] = {};
+    circular::span<int> span(array);
+    const auto& const_span = span;
+    TRIAL_TEST_EQ(const_span.first_unused_segment().size(), 4);
+    span = { 11, 22 };
+    auto segment = const_span.first_unused_segment();
     {
         std::vector<int> expect = { 0, 0 };
         TRIAL_TEST_ALL_EQ(segment.data(), segment.data() + segment.size(),
                           expect.begin(), expect.end());
     }
+    span.push_back(33);
+    span.push_back(44);
+    segment = const_span.first_unused_segment();
+    TRIAL_TEST_EQ(segment.size(), 0);
+
+    span.pop_front();
+    span.pop_front();
+    span.push_back(55);
+    segment = const_span.first_unused_segment();
+    TRIAL_TEST_EQ(segment.size(), 1);
+    TRIAL_TEST_EQ(*segment.begin(), 22);
 }
 
 void dynamic_last_unused_segment()
 {
     int array[4] = {};
     circular::span<int> span(array);
+    TRIAL_TEST_EQ(span.last_unused_segment().size(), 0);
+
     span = { 11, 22 };
     auto segment = span.last_unused_segment();
     {
@@ -584,18 +612,52 @@ void dynamic_last_unused_segment()
         TRIAL_TEST_ALL_EQ(segment.data(), segment.data() + segment.size(),
                           expect.begin(), expect.end());
     }
+
+    span.pop_front();
+    segment = span.last_unused_segment();
+    TRIAL_TEST_EQ(segment.size(), 1);
+    TRIAL_TEST_EQ(*segment.begin(), 11);
+
+    span.pop_front();
+    segment = span.last_unused_segment();
+    {
+        std::vector<int> expect = { 11, 22 };
+        TRIAL_TEST_ALL_EQ(segment.data(), segment.data() + segment.size(),
+                          expect.begin(), expect.end());
+    }
+    span.clear();
+    TRIAL_TEST_EQ(span.last_unused_segment().size(), 0);
 }
 
 void dynamic_last_unused_segment_const()
 {
-    std::array<int, 4> array = { 11, 22 };
-    const circular::span<int> span(array.begin(), array.end(), array.begin(), 2);
-    auto segment = span.last_unused_segment();
+    int array[4] = {};
+    circular::span<int> span(array);
+    const auto& const_span = span;
+    TRIAL_TEST_EQ(const_span.last_unused_segment().size(), 0);
+
+    span = { 11, 22 };
+    auto segment = const_span.last_unused_segment();
     {
         std::vector<int> expect = { };
         TRIAL_TEST_ALL_EQ(segment.data(), segment.data() + segment.size(),
                           expect.begin(), expect.end());
     }
+
+    span.pop_front();
+    segment = const_span.last_unused_segment();
+    TRIAL_TEST_EQ(segment.size(), 1);
+    TRIAL_TEST_EQ(*segment.begin(), 11);
+
+    span.pop_front();
+    segment = const_span.last_unused_segment();
+    {
+        std::vector<int> expect = { 11, 22 };
+        TRIAL_TEST_ALL_EQ(segment.data(), segment.data() + segment.size(),
+                          expect.begin(), expect.end());
+    }
+    span.clear();
+    TRIAL_TEST_EQ(const_span.last_unused_segment().size(), 0);
 }
 
 void run()
@@ -1203,6 +1265,7 @@ void fixed_first_unused_segment()
 {
     int array[4] = {};
     circular::span<int, 4> span(array);
+    TRIAL_TEST_EQ(span.first_unused_segment().size(), 4);
     span = { 11, 22 };
     auto segment = span.first_unused_segment();
     {
@@ -1210,24 +1273,49 @@ void fixed_first_unused_segment()
         TRIAL_TEST_ALL_EQ(segment.data(), segment.data() + segment.size(),
                           expect.begin(), expect.end());
     }
+    span.push_back(33);
+    span.push_back(44);
+    segment = span.first_unused_segment();
+    TRIAL_TEST_EQ(segment.size(), 0);
+
+    span.pop_front();
+    span.pop_front();
+    span.push_back(55);
+    segment = span.first_unused_segment();
+    TRIAL_TEST_EQ(segment.size(), 1);
+    TRIAL_TEST_EQ(*segment.begin(), 22);
 }
 
 void fixed_first_unused_segment_const()
 {
     std::array<int, 4> array = { 11, 22 };
-    const circular::span<int, 4> span(array.begin(), array.end(), array.begin(), 2);
-    auto segment = span.first_unused_segment();
+    circular::span<int, 4> span(array.begin(), array.end(), array.begin(), 2);
+    const auto& const_span = span;
+    auto segment = const_span.first_unused_segment();
     {
         std::vector<int> expect = { 0, 0 };
         TRIAL_TEST_ALL_EQ(segment.data(), segment.data() + segment.size(),
                           expect.begin(), expect.end());
     }
+    span.push_back(33);
+    span.push_back(44);
+    segment = const_span.first_unused_segment();
+    TRIAL_TEST_EQ(segment.size(), 0);
+
+    span.pop_front();
+    span.pop_front();
+    span.push_back(55);
+    segment = const_span.first_unused_segment();
+    TRIAL_TEST_EQ(segment.size(), 1);
+    TRIAL_TEST_EQ(*segment.begin(), 22);
 }
 
 void fixed_last_unused_segment()
 {
     int array[4] = {};
     circular::span<int, 4> span(array);
+    TRIAL_TEST_EQ(span.last_unused_segment().size(), 0);
+
     span = { 11, 22 };
     auto segment = span.last_unused_segment();
     {
@@ -1235,18 +1323,50 @@ void fixed_last_unused_segment()
         TRIAL_TEST_ALL_EQ(segment.data(), segment.data() + segment.size(),
                           expect.begin(), expect.end());
     }
+
+    span.pop_front();
+    segment = span.last_unused_segment();
+    TRIAL_TEST_EQ(segment.size(), 1);
+    TRIAL_TEST_EQ(*segment.begin(), 11);
+
+    span.pop_front();
+    segment = span.last_unused_segment();
+    {
+        std::vector<int> expect = { 11, 22 };
+        TRIAL_TEST_ALL_EQ(segment.data(), segment.data() + segment.size(),
+                          expect.begin(), expect.end());
+    }
+    span.clear();
+    TRIAL_TEST_EQ(span.last_unused_segment().size(), 0);
 }
 
 void fixed_last_unused_segment_const()
 {
     std::array<int, 4> array = { 11, 22 };
-    const circular::span<int, 4> span(array.begin(), array.end(), array.begin(), 2);
-    auto segment = span.last_unused_segment();
+    circular::span<int, 4> span(array.begin(), array.end(), array.begin(), 2);
+    const auto& const_span = span;
+
+    auto segment = const_span.last_unused_segment();
     {
         std::vector<int> expect = { };
         TRIAL_TEST_ALL_EQ(segment.data(), segment.data() + segment.size(),
                           expect.begin(), expect.end());
     }
+
+    span.pop_front();
+    segment = const_span.last_unused_segment();
+    TRIAL_TEST_EQ(segment.size(), 1);
+    TRIAL_TEST_EQ(*segment.begin(), 11);
+
+    span.pop_front();
+    segment = const_span.last_unused_segment();
+    {
+        std::vector<int> expect = { 11, 22 };
+        TRIAL_TEST_ALL_EQ(segment.data(), segment.data() + segment.size(),
+                          expect.begin(), expect.end());
+    }
+    span.clear();
+    TRIAL_TEST_EQ(const_span.last_unused_segment().size(), 0);
 }
 
 void run()


### PR DESCRIPTION
Hi, I found it strange that the const version of first_unused_segment is different from the non-const version and this, indeed, seems to be wrong. The tests then failed with the canonical (non-const) version due to an implementation difference of how `next` is used depending on the constructor, as far as I could tell. I tried my best to make it uniform. It still passes all tests now.